### PR TITLE
explicit lib, corrects for umask errors during extension compilation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+require "bundler"
+require "rake"
+require "bundler/gem_tasks"
+

--- a/lib/mkfifo/version.rb
+++ b/lib/mkfifo/version.rb
@@ -1,0 +1,3 @@
+module Mkfifo
+  VERSION = '0.1.1'
+end

--- a/mkfifo.gemspec
+++ b/mkfifo.gemspec
@@ -1,8 +1,12 @@
-require 'rubygems'
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib/', __FILE__)
+$:.unshift lib unless $:.include?(lib)
+
+require 'mkfifo/version'
 
 Gem::Specification.new do |s|
     s.name          = 'mkfifo'
-    s.version       = '0.1.0'
+    s.version       = Mkfifo::VERSION
     s.author        = 'shura'
     s.email         = 'shura1991@gmail.com'
     s.homepage      = 'http://github.com/shurizzle/ruby-mkfifo'
@@ -13,7 +17,8 @@ Provides Ruby's File class with a new method called ::mkfifo
 that creates a named pipe (FIFO). This gem is a simple C
 extension wrapping the *nixish mkfifo(3) function.
     EOF
-    s.files         = Dir['ext/*.rb'] + Dir['ext/*.c']
+    s.files         = Dir.glob("{lib}/**/*") + Dir['ext/*.rb'] + Dir['ext/*.c']
+    s.require_paths = ["lib"]
     s.extensions    = 'ext/extconf.rb'
     s.extra_rdoc_files = %w[README.rdoc CHANGELOG.rdoc ext/mkfifo.c]
     s.rdoc_options  << "-m" << "README.rdoc" << "-t" << "ruby-mkfifo"


### PR DESCRIPTION
In systems (freebsd, selinux enabled, etc..) that require native compilation by root users, or system gem installations with 'sudo gem install' often the root user has as umask that creates a non world readable directory. 

The .so file is put into a new folder called lib/ruby-mkfifo.so which does not have permissions that allow for non root users to use the extension.

I've migrated the version to lib/mkfifo/version so we have a stub directory 'lib' that will create the correct permissions. 